### PR TITLE
Fix release workflow to create stable releases by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           files: .output/intender-chrome.zip
           generate_release_notes: true
           draft: false
-          prerelease: true
+          prerelease: false
           name: Release v${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intender",
   "description": "manifest.json description",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Changes GitHub Actions to create stable releases instead of prereleases, ensuring /latest/download/ URL works correctly.