### PR TITLE
Fix commit message validation hook placement

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+commit_msg_file="$1"
+commit_msg=$(cat "$commit_msg_file")
+
+if [ ${#commit_msg} -gt 300 ]; then
+  echo "❌ Keep commit messages succinct: explain what you implemented and why, do not go into implementation details." >&2
+  echo "Current length: ${#commit_msg} characters (max: 300)" >&2
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# Check commit message length
-commit_msg=$(git log -1 --pretty=%B)
-if [ ${#commit_msg} -gt 300 ]; then
-  echo "❌ Keep commit messages succinct: explain what you implemented and why, do not go into implementation details."
-  echo "Current length: ${#commit_msg} characters (max: 300)"
-  exit 1
-fi
-
 npx lint-staged 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intender",
   "description": "Set intentions before visiting websites to stay focused and mindful of your browsing goals.",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Moved commit message validation from pre-commit to commit-msg hook. Pre-commit was checking the wrong commit message. Now properly validates current commit message length (300 char limit) with clear error feedback. Version 0.6.2.