### PR TITLE
Docs: clarify unpacked update flow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Block commits on master branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" = "master" ]; then
+  echo "❌ Direct commits to 'master' are not allowed. Please create a branch and open a PR." >&2
+  exit 1
+fi
+
 npx lint-staged 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 # Block commits on master branch
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" = "master" ]; then
-  echo "❌ Direct commits to 'master' are not allowed. Please create a branch and open a PR." >&2
+  echo "❌ Direct commits to 'master' are not allowed. Please create a new branch" >&2
   exit 1
 fi
 

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -41,9 +41,29 @@ Download the latest version: [intender-chrome.zip](https://github.com/jonathanmo
 
 ## Updating
 
-- Before switching builds or reinstalling, open Intender → Settings.
-- Click the "⋯" (more options) button and select "Export Intentions" to download a `.json` backup.
-- After installing the new build, open Settings, click "⋯" and select "Import Intentions" to restore.
+### For Testers (Unpacked Extension)
+
+1. **Backup your data** (optional but recommended):
+   - Open Intender → Settings
+   - Click "⋯" (more options) → "Export Settings" to download a backup
+
+2. **Update the extension (overwrite in place)**:
+   - Download the latest [intender-chrome.zip](https://github.com/jonathanmoregard/intender/releases/latest/download/intender-chrome.zip)
+   - Extract it into the SAME folder as your previous extraction and choose "Replace/Overwrite" when prompted
+   - Keep the folder path unchanged so Chrome’s "Load unpacked" continues pointing at the same `chrome-mv3` directory
+   - Go to `chrome://extensions/` and click the reload icon on the Intender card (or click the global "Update" button)
+
+3. **Verify the update**:
+   - Check the version shown on the Intender card matches the new build
+   - Open the popup and Settings to confirm everything loads correctly
+
+4. **Restore data (only if needed)**:
+   - Open Settings → "⋯" → "Import Settings" to restore your backup
+
+### For Production Users
+
+- Updates are handled automatically through the Chrome Web Store
+- No manual action required
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intender",
   "description": "Set intentions before visiting websites to stay focused and mindful of your browsing goals.",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.4",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Clarify how to update the unpacked extension during testing.

- Recommend extracting new zip over the same folder
- Reload from chrome://extensions (keep path stable)
- Optional backup/restore via Settings
- Add pre-commit guard against committing on master
- Bump version to 0.6.4