### PR TITLE
Fix: make intention-completed query param globally unique

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -948,7 +948,7 @@ export default defineBackground(async () => {
       try {
         const targetUrlObj = new URL(targetUrl);
         const intentionCompleted = targetUrlObj.searchParams.get(
-          'intention_completed'
+          'intention_completed_53c5890'
         );
 
         if (intentionCompleted === 'true') {

--- a/entrypoints/intention-page/main.ts
+++ b/entrypoints/intention-page/main.ts
@@ -248,7 +248,7 @@ storage
             e.preventDefault(); // Prevent newline from being added
             if (acceptableCompletePrompt(inputEl.value)) {
               const targetUrl = new URL(target!);
-              targetUrl.searchParams.set('intention_completed', 'true');
+              targetUrl.searchParams.set('intention_completed_53c5890', 'true');
               window.location.href = targetUrl.toString();
             }
           }
@@ -266,7 +266,7 @@ storage
             // Navigate after animation
             setTimeout(() => {
               const targetUrl = new URL(target!);
-              targetUrl.searchParams.set('intention_completed', 'true');
+              targetUrl.searchParams.set('intention_completed_53c5890', 'true');
               window.location.href = targetUrl.toString();
             }, 200);
           }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intender",
   "description": "Set intentions before visiting websites to stay focused and mindful of your browsing goals.",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Changed query parameter from 'intention_completed' to 'intention_completed_53c5890' to ensure global uniqueness and avoid conflicts with other extensions or websites using the same parameter name. Version bumped to 0.6.5.